### PR TITLE
Rename find-package(kodi) to Kodi, fix includes and get addon.xml inline with other add-ons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 2.6)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 
-find_package(kodi REQUIRED)
+find_package(Kodi REQUIRED)
 find_package(platform REQUIRED)
 find_package(kodiplatform REQUIRED)
 

--- a/src/core/Vortex.cpp
+++ b/src/core/Vortex.cpp
@@ -37,7 +37,7 @@
 #include "scriptstring.h"
 
 #include "DebugConsole.h"
-#include "kodi/xbmc_vis_types.h"
+#include "xbmc_vis_types.h"
 
 // Effects
 #include "Map.h"

--- a/visualization.vortex/addon.xml.in
+++ b/visualization.vortex/addon.xml.in
@@ -6,7 +6,7 @@
   provider-name="Team-Kodi">
   <extension
     point="xbmc.player.musicviz"
-    library_windx="visualization.vortex.dll"/>
+    library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="xbmc.addon.metadata">
     <summary lang="af">Vortex Visualisasie van die XBOX paket</summary>
     <summary lang="ar">تصور دوامة من حزمة XBOX</summary>
@@ -53,6 +53,6 @@
     <summary lang="th">การแสดง Vortex จาก XBOX package</summary>
     <summary lang="tr">XBOX paketinden Vortex Görsel Öğe</summary>
     <summary lang="zh">来自 XBOX 组件包的旋涡可视化效果</summary>
-    <platform>windx</platform>
+    <platform>@PLATFORM@</platform>
   </extension>
 </addon>

--- a/visualization.vortex/addon.xml.in
+++ b/visualization.vortex/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="visualization.vortex"
-  version="1.5.0"
+  version="1.6.0"
   name="Vortex"
   provider-name="Team-Kodi">
   <extension


### PR DESCRIPTION
Package renaming is needed after https://github.com/xbmc/xbmc/pull/9750 goes in.
The rest is to bring xml files up to par.
