### PR TITLE
fix compile error for VS 2017

### DIFF
--- a/src/angelscript/add_on/scriptstring.cpp
+++ b/src/angelscript/add_on/scriptstring.cpp
@@ -593,12 +593,16 @@ void RegisterScriptString_Native(asIScriptEngine *engine)
 	if( sizeof(size_t) == 4 )
 	{
 		r = engine->RegisterObjectMethod("string", "uint length() const", asMETHOD(string,size), asCALL_THISCALL); assert( r >= 0 );
+#if !defined(_MSC_VER) || _MSC_VER <= 1911
 		r = engine->RegisterObjectMethod("string", "void resize(uint)", asMETHODPR(string,resize,(size_t),void), asCALL_THISCALL); assert( r >= 0 );
+#endif
 	}
 	else
 	{
 		r = engine->RegisterObjectMethod("string", "uint64 length() const", asMETHOD(string,size), asCALL_THISCALL); assert( r >= 0 );
+#if !defined(_MSC_VER) || _MSC_VER <= 1911
 		r = engine->RegisterObjectMethod("string", "void resize(uint64)", asMETHODPR(string,resize,(size_t),void), asCALL_THISCALL); assert( r >= 0 );
+#endif
 	}
 
     // TODO: Add factory  string(const string &in str, int repeatCount)

--- a/visualization.vortex/addon.xml.in
+++ b/visualization.vortex/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="visualization.vortex"
-  version="2.0.0"
+  version="2.0.1"
   name="Vortex"
   provider-name="Team-Kodi">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
Visual Studio 2015 shipped a std::string which had `void resize (size_t n)` and `void resize (size_t n, char c)` as explicit functions.
In VS 2017 only one resize function exists, with the second argument having a default argument. Because of that, the function pointer can't be used any more as it would require to set both parameters, if it gets called from a function pointer.